### PR TITLE
Reuse existing voice connections

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -1,6 +1,7 @@
-import { SlashCommandBuilder, CommandInteraction, CacheType } from "discord.js";
+import { SlashCommandBuilder } from "discord.js";
 import {
   joinVoiceChannel,
+  getVoiceConnection,
   AudioPlayerStatus,
   VoiceConnection,
 } from "@discordjs/voice";
@@ -23,23 +24,6 @@ function formatTime(seconds: number): string {
   }${remainingSeconds} minutes`;
 }
 
-function getConnection(
-  interaction: CommandInteraction<CacheType>
-): VoiceConnection | null {
-  const member = interaction.member;
-  const guild = interaction.guild;
-
-  if (!member || !("voice" in member) || !member.voice.channel || !guild) {
-    console.log("Invalid member.");
-    return null;
-  }
-
-  return joinVoiceChannel({
-    channelId: member.voice.channel.id,
-    guildId: guild.id,
-    adapterCreator: guild.voiceAdapterCreator,
-  });
-}
 
 const playCommand = {
   name: "play",
@@ -84,11 +68,14 @@ const playCommand = {
         return "Could not find the voice channel.";
       }
 
-      const connection = joinVoiceChannel({
-        channelId: voiceChannelId,
-        guildId: guild.id,
-        adapterCreator: guild.voiceAdapterCreator,
-      });
+      let connection = getVoiceConnection(guild.id);
+      if (!connection) {
+        connection = joinVoiceChannel({
+          channelId: voiceChannelId,
+          guildId: guild.id,
+          adapterCreator: guild.voiceAdapterCreator,
+        });
+      }
 
       setConnection(connection);
 

--- a/src/commands/resume.ts
+++ b/src/commands/resume.ts
@@ -6,7 +6,7 @@ import {
   queue,
   playNextSong,
 } from "../index";
-import { AudioPlayerStatus, joinVoiceChannel } from "@discordjs/voice";
+import { AudioPlayerStatus, joinVoiceChannel, getVoiceConnection } from "@discordjs/voice";
 import JSONStorage from "../utils/storage";
 
 export default {
@@ -26,11 +26,14 @@ export default {
         return `Could not find the guild: ${data.guildId}.`;
       }
 
-      const connection = joinVoiceChannel({
-        channelId: voiceChannelId,
-        guildId: guild.id,
-        adapterCreator: guild.voiceAdapterCreator,
-      });
+      let connection = getVoiceConnection(guild.id);
+      if (!connection) {
+        connection = joinVoiceChannel({
+          channelId: voiceChannelId,
+          guildId: guild.id,
+          adapterCreator: guild.voiceAdapterCreator,
+        });
+      }
 
       setConnection(connection);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,9 @@ export function getConnection() {
 }
 
 export function setConnection(newConnection: VoiceConnection) {
+  if (connection && connection !== newConnection) {
+    connection.destroy();
+  }
   connection = newConnection;
 }
 


### PR DESCRIPTION
## Summary
- avoid creating duplicate voice connections in **play** and **resume** commands
- destroy previous connection when setting a new one

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845fd72b4048328a97302f2264c1c10